### PR TITLE
Add thread creation feature with UI, schemas, and API integration

### DIFF
--- a/app/(public)/threads/create/page.tsx
+++ b/app/(public)/threads/create/page.tsx
@@ -1,0 +1,5 @@
+import { ThreadCreateView } from "@/modules/threads/ui/views/thread-create-view";
+
+export default function ThreadCreatePage() {
+	return <ThreadCreateView />;
+}

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -46,6 +46,7 @@ const eslintConfig = tseslint.config(
 			"@typescript-eslint/no-unsafe-member-access": "off",
 			"@typescript-eslint/no-unsafe-call": "off",
 			"@typescript-eslint/no-unsafe-assignment": "off",
+			"@typescript-eslint/no-unsafe-return": "off",
 		},
 		linterOptions: {
 			reportUnusedDisableDirectives: true,

--- a/modules/threads/schemas/index.ts
+++ b/modules/threads/schemas/index.ts
@@ -1,0 +1,14 @@
+import { z } from "zod";
+
+export const threadInsertSchema = z.object({
+	title: z
+		.string()
+		.min(1, { message: "Title is required" })
+		.max(100, { message: "Title is too long" }),
+	content: z
+		.string()
+		.min(1, { message: "Content is required" })
+		.max(1500, { message: "Content is too long" }),
+});
+
+export type ThreadInsertSchema = z.infer<typeof threadInsertSchema>;

--- a/modules/threads/server/procedures.ts
+++ b/modules/threads/server/procedures.ts
@@ -1,0 +1,16 @@
+import { threadInsertSchema } from "@/modules/threads/schemas";
+import { createTRPCRouter, publicProcedure } from "@/trpc/init";
+
+export const threadsRouter = createTRPCRouter({
+	create: publicProcedure
+		.input(threadInsertSchema)
+		.mutation(async ({ ctx, input }) => {
+			const thread = await ctx.db.thread.create({
+				data: {
+					...input,
+				},
+			});
+
+			return thread;
+		}),
+});

--- a/modules/threads/ui/components/thread-form.tsx
+++ b/modules/threads/ui/components/thread-form.tsx
@@ -1,0 +1,109 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useMutation } from "@tanstack/react-query";
+import { Loader2Icon } from "lucide-react";
+import { useForm } from "react-hook-form";
+import { toast } from "sonner";
+
+import { Button } from "@/components/ui/button";
+import {
+	Form,
+	FormControl,
+	FormField,
+	FormItem,
+	FormLabel,
+	FormMessage,
+} from "@/components/ui/form";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import {
+	threadInsertSchema,
+	type ThreadInsertSchema,
+} from "@/modules/threads/schemas";
+import { useTRPC } from "@/trpc/client";
+
+export const ThreadForm = () => {
+	const router = useRouter();
+
+	const trpc = useTRPC();
+
+	const form = useForm<ThreadInsertSchema>({
+		resolver: zodResolver(threadInsertSchema),
+		defaultValues: {
+			title: "",
+			content: "",
+		},
+		mode: "all",
+	});
+
+	const createThread = useMutation(
+		trpc.threads.create.mutationOptions({
+			onSuccess: async (data) => {
+				toast.success("Your thread has been created.");
+
+				router.push(`/threads/${data.id}`);
+			},
+
+			onError: (error) => {
+				toast.error("Oops, something went wrong.", {
+					description: error.message,
+				});
+			},
+		})
+	);
+
+	const isPending = createThread.isPending;
+
+	const onSubmit = async (data: ThreadInsertSchema) => {
+		await createThread.mutateAsync(data);
+	};
+
+	return (
+		<Form {...form}>
+			<form onSubmit={form.handleSubmit(onSubmit)} className="grid gap-8">
+				<div className="grid gap-4">
+					<FormField
+						control={form.control}
+						name="title"
+						render={({ field }) => (
+							<FormItem>
+								<FormLabel>Title</FormLabel>
+								<FormControl>
+									<Input placeholder="Title" {...field} />
+								</FormControl>
+								<FormMessage />
+							</FormItem>
+						)}
+					/>
+
+					<FormField
+						control={form.control}
+						name="content"
+						render={({ field }) => (
+							<FormItem>
+								<FormLabel>Content</FormLabel>
+								<FormControl>
+									<Textarea placeholder="Content" rows={6} {...field} />
+								</FormControl>
+								<FormMessage />
+							</FormItem>
+						)}
+					/>
+				</div>
+
+				<Button type="submit" className="w-full" disabled={isPending}>
+					{isPending ? (
+						<>
+							<Loader2Icon className="animate-spin" /> Creating...
+						</>
+					) : (
+						"Create Thread"
+					)}
+				</Button>
+			</form>
+		</Form>
+	);
+};

--- a/modules/threads/ui/views/thread-create-view.tsx
+++ b/modules/threads/ui/views/thread-create-view.tsx
@@ -1,0 +1,25 @@
+import {
+	Card,
+	CardContent,
+	CardDescription,
+	CardHeader,
+	CardTitle,
+} from "@/components/ui/card";
+import { ThreadForm } from "@/modules/threads/ui/components/thread-form";
+
+export const ThreadCreateView = () => {
+	return (
+		<div className="w-full">
+			<Card className="mx-auto mt-12">
+				<CardHeader>
+					<CardTitle>Start a new thread</CardTitle>
+					<CardDescription>You can start a new thread here.</CardDescription>
+				</CardHeader>
+
+				<CardContent>
+					<ThreadForm />
+				</CardContent>
+			</Card>
+		</div>
+	);
+};

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -10,7 +10,7 @@ datasource db {
   url      = env("DATABASE_URL")
 }
 
-model Post {
+model Thread {
   id      String @id @default(cuid())
   title   String
   content String
@@ -18,5 +18,5 @@ model Post {
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
 
-  @@map("posts")
+  @@map("threads")
 }

--- a/trpc/routers/index.ts
+++ b/trpc/routers/index.ts
@@ -1,23 +1,8 @@
-import { z } from "zod";
-
-import {
-	createCallerFactory,
-	createTRPCRouter,
-	publicProcedure,
-} from "@/trpc/init";
+import { threadsRouter } from "@/modules/threads/server/procedures";
+import { createCallerFactory, createTRPCRouter } from "@/trpc/init";
 
 export const appRouter = createTRPCRouter({
-	hello: publicProcedure
-		.input(
-			z.object({
-				text: z.string(),
-			})
-		)
-		.query((opts) => {
-			return {
-				greeting: `hello ${opts.input.text}`,
-			};
-		}),
+	threads: threadsRouter,
 });
 
 // export type definition of API


### PR DESCRIPTION
- Implement thread creation page and form components
- Add Zod schemas for thread validation
- Create tRPC procedures for thread creation
- Update Prisma schema and tRPC routers
- Adjust ESLint config to allow unsafe returns for new code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added a “Start a new thread” page with a form to create threads (title and content), including validation, loading states, success notifications, and automatic redirect to the new thread.
- Refactor
  - Updated terminology from “Post” to “Thread” across the app, reflecting in UI labels and routes.
- Chores
  - Adjusted linting rules to ease TypeScript return checks.
- API
  - Introduced a modular threads API route, replacing the previous placeholder endpoint.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->